### PR TITLE
fix pod link

### DIFF
--- a/lib/Mercury.pm
+++ b/lib/Mercury.pm
@@ -17,7 +17,7 @@ application that is started when you use C<mercury broker>.
 
 To learn how to use this application to broker messages, see L<the main
 Mercury documentation|mercury>. For how to start the broker application,
-see L<the mercury broker command documentation|Mercury::Command::broker>
+see L<the mercury broker command documentation|Mercury::Command::mercury::broker>
 or run C<mercury help broker>.
 
 To learn how to create a custom message broker to integrate authentication,


### PR DESCRIPTION
link currently points to `Mercury::Command::broker` instead of `Mercury::Command::mercury::broker`